### PR TITLE
Updating juno testnet presents from uni-3 to uni-5

### DIFF
--- a/src/features/connection/presets.json
+++ b/src/features/connection/presets.json
@@ -12,9 +12,9 @@
   },
   "juno-uni": {
     "chainName": "Juno Testnet - Uni",
-    "chainId": "uni-3",
-    "rpcEndpoint": "https://rpc.uni.juno.deuslabs.fi",
-    "restEndpoint": "https://lcd.uni.juno.deuslabs.fi",
+    "chainId": "uni-5",
+    "rpcEndpoint": "https://rpc.uni.junonetwork.io",
+    "restEndpoint": "https://api.uni.junonetwork.io",
     "addressPrefix": "juno",
     "microDenom": "ujunox",
     "coinDecimals": "6",


### PR DESCRIPTION
The existing endpoints for uni-3 are not working with the new testnet.

Changing the chain-id as well as the endpoints to the official ones